### PR TITLE
RUBY_ROOT should be full path, not relative

### DIFF
--- a/bin/vruby
+++ b/bin/vruby
@@ -160,7 +160,7 @@ sub_embed() {
 RUBY_VERSION=$version
 RUBY_ENGINE=ruby
 
-export RUBY_ROOT=$target_dir
+export RUBY_ROOT=$host_dir/$target_dir
 export GEM_HOME="$host_dir/.gem/\$RUBY_ENGINE/\$RUBY_VERSION"
 export GEM_PATH=\$GEM_HOME
 


### PR DESCRIPTION
- otherwise Ruby commands (irb, ruby, etc) do not work in child
  folders of the project, only in the root folder
