### PR TITLE
RUBY_ROOT does not need to be exported

### DIFF
--- a/bin/vruby
+++ b/bin/vruby
@@ -160,8 +160,8 @@ sub_embed() {
   activate=$(cat <<-EOF
 RUBY_VERSION=$version
 RUBY_ENGINE=ruby
+RUBY_ROOT=$host_dir/$target_dir
 
-export RUBY_ROOT=$host_dir/$target_dir
 export GEM_HOME="$host_dir/.gem/\$RUBY_ENGINE/\$RUBY_VERSION"
 export GEM_PATH=\$GEM_HOME
 


### PR DESCRIPTION
Why is this exported?  I can't find where Ruby or Rubygems cares about this variable.  Am I missing something?
